### PR TITLE
Fix to make ingredient tracker update during battle

### DIFF
--- a/Avabur_Enhancer.user.js
+++ b/Avabur_Enhancer.user.js
@@ -747,8 +747,8 @@ function parseAutobattlePhp(battle) {
             localStorage.LocDrops = JSON.stringify(drops);
         } else {
             console.log("No Web Storage support to track drops.");
-            $('#ingredientDropList').html(loadIngredientDropList());
         }
+        $('#ingredientDropList').html(loadIngredientDropList());
     }
 
     // Battle was won and Drop Tracker enabled


### PR DESCRIPTION
In battle the loadIngredientDropList function is nested incorrectly so it will not cause updates without a refresh or switching to ts and getting a drop